### PR TITLE
customize api url dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IndigoTrace SDK
 
-This javascript module exposes functions to communicate with the Indigo Trace API. You will first need to sign up for an account at indigotrace.com. Once you have created an *input*, you will need its private key to interact with the API.
+This javascript module exposes functions to communicate with the Indigo Trace API. You will first need to sign up for an account at indigotrace.com. Once you have created an _input_, you will need its private key to interact with the API.
 
 ## Usage
 
@@ -16,8 +16,13 @@ const myKey = {
     "VD6zmq068l1EhaWfpRQxnlpTjGbwSN2q2XcgriBmo3Mco+7GK+BPLO49yxuQzbQ1dzd/6B+3YQb2c3BhqEaTsA=="
 };
 
-// Initialize the SDK with the API's URL.
-const sdk = TraceSdk(myKey);
+// The url of the API
+const url = 'https://api.indigotrace.com';
+
+// Initialize the SDK with the key and optionally the API's URL.
+// If you omit the url, it will default to the production environment
+// https://api.indigotrace.com
+const sdk = TraceSdk(myKey, url);
 
 // This is an example of data we want to send to Indigo Trace.
 const data = {
@@ -76,37 +81,40 @@ sdk.send(payload).then(rsp => {
 Head over to indigotrace.com and have a look at your workflow to see the new event in the traces section. You can inspect the content of the payload from there.
 
 ## Retrieve traces
+
 The SDK can also retrieve existing traces and events:
+
 ```javascript
 // If you know the traceID, you can use it directly to retrive the trace content:
-sdk.getTrace('db255d6d-8e7f-45e6-99f8-cf9f1084ba9b').then(rsp => {
+sdk.getTrace("db255d6d-8e7f-45e6-99f8-cf9f1084ba9b").then(rsp => {
   // Extract the information from the trace.
-  const { trace_id, events} = rsp;
+  const { trace_id, events } = rsp;
   events.forEach(e => {
     const { data, event_id, action, updated_at } = e;
     console.log(data);
-  })
-})
+  });
+});
 
 // If you don't know the trace id you can get all traces at once.
 sdk.getTraces().then(rsp => {
   // Extract the information from the traces.
   const { workflow_id, traces } = rsp;
   traces.forEach(trace => {
-    const { trace_id, events} = trace;
+    const { trace_id, events } = trace;
     events.forEach(e => {
       const { data, event_id, action, updated_at } = e;
       console.log(data);
-    })
-  })
+    });
+  });
 });
 ```
 
 ## Verify payload signatures
 
 Given a signed payload, it is possible to veify that the signatures are correct:
+
 ```javascript
-if ( !sdk.verify(signedPayload) ) {
-  throw new Error('Cannot verify this signature...');
+if (!sdk.verify(signedPayload)) {
+  throw new Error("Cannot verify this signature...");
 }
 ```

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,7 @@
 export const API_URL =
   process.env.INDIGOTRACE_API_URL ||
   process.env.REACT_APP_INDIGOTRACE_API_URL ||
-  'https://staging-api.indigotrace.com';
+  'https://api.indigotrace.com';
 export const API_VERSION =
   process.env.INDIGOTRACE_API_VERSION ||
   process.env.REACT_APP_INDIGOTRACE_API_VERSION ||

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { sign } from 'tweetnacl';
 import { stringify } from 'canonicaljson';
 
 import request from './request';
-import { ROUTE_SDK_TRACES, ROUTE_SDK_AUTH } from './constants';
+import { ROUTE_SDK_TRACES, ROUTE_SDK_AUTH, API_URL } from './constants';
 import validate from './validate';
 import { encodeB64, decodeB64 } from './utils';
 
@@ -22,7 +22,7 @@ class Trace {
    * @param {string} [APIUrl] -  the API base url to use for the requests (defaults to constants.API_URL)
    * @returns {Trace} - an trace SDK
    */
-  constructor(key, APIUrl = null) {
+  constructor(key, APIUrl = API_URL) {
     if (!isHandledAlg(key.type)) {
       throw new Error(`${key.type} : Unhandled key type`);
     } else if (!key.secret) {
@@ -221,6 +221,6 @@ class Trace {
   }
 }
 
-export default function(key, APIUrl = null) {
+export default function(key, APIUrl = API_URL) {
   return new Trace(key, APIUrl);
 }

--- a/src/request.js
+++ b/src/request.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 import httpAdapter from 'axios/lib/adapters/http';
-import { API_URL } from './constants';
 
 axios.defaults.adapter = httpAdapter;
-axios.defaults.baseURL = API_URL;
 
 const request = (method, route, options) => {
   const config = {

--- a/src/request.js
+++ b/src/request.js
@@ -15,6 +15,7 @@ const request = (method, route, options) => {
   if (options) {
     if (options.data) config.data = options.data;
     if (options.auth) config.headers.Authorization = options.auth;
+    if (options.baseURL) config.baseURL = options.baseURL;
   }
 
   return axios.request(config).then(({ data }) => data);

--- a/src/request.test.js
+++ b/src/request.test.js
@@ -13,7 +13,7 @@ describe('request', () => {
     requestStub.resetHistory();
   });
 
-  it('has correct config', done => {
+  it('has correct config', () =>
     request('post', '/route').then(data => {
       expect(requestStub).to.have.been.calledOnce;
       expect(requestStub).to.have.been.calledWith({
@@ -22,11 +22,9 @@ describe('request', () => {
         headers: { 'Content-Type': 'application/json' }
       });
       expect(data).to.equal('data');
-      done();
-    });
-  });
+    }));
 
-  it('has sets the Authorization header when called with auth option', done => {
+  it('sets the Authorization header when called with auth option', () =>
     request('post', '/route', { auth: 'pass' }).then(data => {
       expect(requestStub).to.have.been.calledOnce;
       expect(requestStub).to.have.been.calledWith({
@@ -38,11 +36,9 @@ describe('request', () => {
         }
       });
       expect(data).to.equal('data');
-      done();
-    });
-  });
+    }));
 
-  it('has sets the Authorization header when called with auth option', done => {
+  it('sets data when called with data option', () =>
     request('post', '/route', { data: 'body' }).then(data => {
       expect(requestStub).to.have.been.calledOnce;
       expect(requestStub).to.have.been.calledWith({
@@ -54,7 +50,18 @@ describe('request', () => {
         }
       });
       expect(data).to.equal('data');
-      done();
-    });
-  });
+    }));
+
+  it('sets data when called with data option', () =>
+    request('get', '/route', { baseURL: 'foo/bar' }).then(() => {
+      expect(requestStub).to.have.been.calledOnce;
+      expect(requestStub).to.have.been.calledWith({
+        baseURL: 'foo/bar',
+        url: '/route',
+        method: 'get',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }));
 });

--- a/src/trace.test.js
+++ b/src/trace.test.js
@@ -4,7 +4,7 @@ import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 
 import makeSdk from './';
-import { ROUTE_SDK_TRACES, ROUTE_SDK_AUTH } from './constants';
+import { ROUTE_SDK_TRACES, ROUTE_SDK_AUTH, API_URL } from './constants';
 import * as validate from './validate';
 import * as request from './request';
 
@@ -34,7 +34,7 @@ describe('Trace', () => {
       'post',
       ROUTE_SDK_AUTH,
       {
-        baseURL: null,
+        baseURL: API_URL,
         data: {
           type: 'type',
           public_key: '12345',
@@ -57,7 +57,7 @@ describe('Trace', () => {
       'post',
       '/route',
       {
-        baseURL: null,
+        baseURL: API_URL,
         data: 'body',
         auth: 'apikey'
       }
@@ -79,7 +79,7 @@ describe('Trace', () => {
       'post',
       '/route',
       {
-        baseURL: null,
+        baseURL: API_URL,
         data: 'body',
         auth: 'apikey'
       }


### PR DESCRIPTION
- user can now pass an optional `apiUrl` argument when creating the sdk. Allows for more flexibility vs using env variable.
- `sdk.authenticate()` will set the `APIkey` member to the class so that it can be called by user to build logic on top of that, without re authenticating next time:
```
sdk.authenticate().then(ok).catch(error);
sdk.send(); // will not create a second auth request
```
- updated readme as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/trace-sdk-js/19)
<!-- Reviewable:end -->
